### PR TITLE
feat: Enhance hobby and profile pages with icons

### DIFF
--- a/pages/hobby/index.vue
+++ b/pages/hobby/index.vue
@@ -2,36 +2,48 @@
   <div>
     <h1 class="text-4xl font-bold text-center mb-8">Hobby</h1>
     <div class="space-y-8">
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">お酒</h2>
-        <p class="text-gray-700 leading-relaxed">
-          特にウイスキーが好きです! 好きな銘柄はラガブーリン16年です。
-          ビールもワインも飲みます。ジン、ウォッカ、ラム、ワイン、日本酒、焼酎何でも飲めます。
-        </p>
+      <div class="bg-white p-6 rounded-lg shadow-md flex items-center space-x-6">
+        <font-awesome-icon icon="whiskey-glass" class="text-4xl text-gray-500" />
+        <div>
+          <h2 class="text-2xl font-semibold mb-2">お酒</h2>
+          <p class="text-gray-700 leading-relaxed">
+            特にウイスキーが好きです! 好きな銘柄はラガブーリン16年です。
+            ビールもワインも飲みます。ジン、ウォッカ、ラム、ワイン、日本酒、焼酎何でも飲めます。
+          </p>
+        </div>
       </div>
 
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">海外旅行</h2>
-        <p class="text-gray-700 leading-relaxed">
-          学生時代はバックパッカーで世界各国を旅していました。
-          今までで約30ヶ国に行きました。好きな国はハンガリーやウズベキスタンです。
-          今でも長期の休暇があればフラっと海外に行ったりしています!
-        </p>
+      <div class="bg-white p-6 rounded-lg shadow-md flex items-center space-x-6">
+        <font-awesome-icon icon="plane-departure" class="text-4xl text-gray-500" />
+        <div>
+          <h2 class="text-2xl font-semibold mb-2">海外旅行</h2>
+          <p class="text-gray-700 leading-relaxed">
+            学生時代はバックパッカーで世界各国を旅していました。
+            今までで約30ヶ国に行きました。好きな国はハンガリーやウズベキスタンです。
+            今でも長期の休暇があればフラっと海外に行ったりしています!
+          </p>
+        </div>
       </div>
 
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">映画</h2>
-        <p class="text-gray-700 leading-relaxed">
-          映画も好きでよく見ています。シネコンよりも単館が好きです。
-          好きな監督はホドロフスキーで特にホーリー・マウンテンが好きです。
-        </p>
+      <div class="bg-white p-6 rounded-lg shadow-md flex items-center space-x-6">
+        <font-awesome-icon icon="film" class="text-4xl text-gray-500" />
+        <div>
+          <h2 class="text-2xl font-semibold mb-2">映画</h2>
+          <p class="text-gray-700 leading-relaxed">
+            映画も好きでよく見ています。シネコンよりも単館が好きです。
+            好きな監督はホドロフスキーで特にホーリー・マウンテンが好きです。
+          </p>
+        </div>
       </div>
 
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">ボードゲーム</h2>
-        <p class="text-gray-700 leading-relaxed">
-          週末はよくボードゲームをしています。好きなボードゲームはバトルラインです!
-        </p>
+      <div class="bg-white p-6 rounded-lg shadow-md flex items-center space-x-6">
+        <font-awesome-icon icon="chess-board" class="text-4xl text-gray-500" />
+        <div>
+          <h2 class="text-2xl font-semibold mb-2">ボードゲーム</h2>
+          <p class="text-gray-700 leading-relaxed">
+            週末はよくボードゲームをしています。好きなボードゲームはバトルラインです!
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/pages/profile/index.vue
+++ b/pages/profile/index.vue
@@ -3,7 +3,10 @@
     <h1 class="text-4xl font-bold text-center mb-8">Profile</h1>
     <div class="space-y-8">
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">Summary</h2>
+        <h2 class="text-2xl font-semibold mb-4 flex items-center">
+          <font-awesome-icon icon="user" class="mr-3 text-gray-500" />
+          Summary
+        </h2>
         <p class="text-gray-700 leading-relaxed">
           1990年三重県生まれ、奈良県育ちのWebエンジニア・エンジニアリングマネージャーです。関西学院大学大学院で計量社会学を専攻し、統計解析とプログラミングの基礎を習得しました。
           <br/><br/>
@@ -16,31 +19,34 @@
       </div>
 
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">経歴・実績</h2>
+        <h2 class="text-2xl font-semibold mb-4 flex items-center">
+          <font-awesome-icon icon="briefcase" class="mr-3 text-gray-500" />
+          経歴・実績
+        </h2>
         <div class="text-gray-700 leading-relaxed">
           <div class="mb-4">
             <h3 class="text-lg font-semibold text-gray-800">学歴</h3>
             <p>2013年3月 関西学院大学社会学部 卒業</p>
             <p>2015年3月 関西学院大学大学院社会学研究科 修了</p>
           </div>
-          
+
           <div class="mb-4">
             <h3 class="text-lg font-semibold text-gray-800">職歴</h3>
             <p><strong>2024年11月 - 現在</strong> 株式会社TRUSTDOCK（エンジニアリングマネージャー）</p>
             <p class="text-sm text-gray-600 ml-4">eKYC・本人確認サービスの開発チーム運営・技術戦略策定</p>
-            
+
             <p><strong>2022年1月 - 2024年10月</strong> 株式会社ココナラ（チームマネージャー）</p>
             <p class="text-sm text-gray-600 ml-4">スキルマーケット「ココナラ」の開発チーム運営・バックエンド開発</p>
-            
+
             <p><strong>2021年5月 - 2021年12月</strong> フリーランスエンジニア</p>
             <p class="text-sm text-gray-600 ml-4">Ruby on Rails / Vue.js を用いたWebアプリケーション開発</p>
-            
+
             <p><strong>2019年1月 - 2021年4月</strong> 株式会社MERY（エンジニア）</p>
             <p class="text-sm text-gray-600 ml-4">女性向けライフスタイルメディア「MERY」の開発・運用</p>
-            
+
             <p><strong>2016年12月 - 2018年12月</strong> 株式会社ミンカブ・ジ・インフォノイド（エンジニア）</p>
             <p class="text-sm text-gray-600 ml-4">金融情報サービスの開発・データ分析基盤構築</p>
-            
+
             <p><strong>2015年4月 - 2016年11月</strong> SIer企業（システムエンジニア）</p>
             <p class="text-sm text-gray-600 ml-4">官公庁向けシステム開発・保守</p>
           </div>
@@ -48,7 +54,10 @@
       </div>
 
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-semibold mb-4">エンジニアとしての強み・志向</h2>
+        <h2 class="text-2xl font-semibold mb-4 flex items-center">
+          <font-awesome-icon icon="laptop-code" class="mr-3 text-gray-500" />
+          エンジニアとしての強み・志向
+        </h2>
         <div class="text-gray-700 leading-relaxed">
           <div class="mb-4">
             <h3 class="text-lg font-semibold text-gray-800">技術的強み</h3>
@@ -59,7 +68,7 @@
               <li><strong>フロントエンド・インフラ</strong>：Vue.js / AWS 等も扱えるが補助的な位置づけ</li>
             </ul>
           </div>
-          
+
           <div class="mb-4">
             <h3 class="text-lg font-semibold text-gray-800">マネジメント・ヒューマンスキル</h3>
             <ul class="list-disc list-inside ml-4 space-y-1">
@@ -69,7 +78,7 @@
               <li><strong>ステークホルダー調整</strong>：技術要件と事業要件のバランス調整</li>
             </ul>
           </div>
-          
+
           <div class="mb-4">
             <h3 class="text-lg font-semibold text-gray-800">開発・チーム運営の考え方</h3>
             <ul class="list-disc list-inside ml-4 space-y-1">

--- a/plugins/fontawesome.js
+++ b/plugins/fontawesome.js
@@ -31,6 +31,13 @@ import {
   faChartLine,
   faProjectDiagram,
   faSitemap,
+  faWhiskeyGlass,
+  faPlaneDeparture,
+  faFilm,
+  faChessBoard,
+  faUser,
+  faBriefcase,
+  faLaptopCode,
 } from '@fortawesome/free-solid-svg-icons'
 
 // CSSの自動追加を防ぐ（nuxt.configでスタイルを読み込んでいるため）
@@ -64,7 +71,14 @@ library.add(
   faBug,
   faChartLine,
   faProjectDiagram,
-  faSitemap
+  faSitemap,
+  faWhiskeyGlass,
+  faPlaneDeparture,
+  faFilm,
+  faChessBoard,
+  faUser,
+  faBriefcase,
+  faLaptopCode
 )
 
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
This commit enhances the design of the Hobby and Profile pages by adding Font Awesome icons and improving the layout.

On the Hobby page, each hobby section now has a relevant icon and is laid out using flexbox for better alignment.

On the Profile page, icons have been added to the main section headers (Summary, Career, Strengths) to improve visual structure.

The necessary icons were added to the Font Awesome library configuration.